### PR TITLE
Fix locking errors

### DIFF
--- a/multierror.go
+++ b/multierror.go
@@ -9,15 +9,13 @@ import (
 // MultiError implements error interface.
 // An instance of MultiError has zero or more errors.
 type MultiError struct {
-	mutex *sync.Mutex
+	mutex sync.Mutex
 	errs  []error
 }
 
 // NewMultiError: returns a thread safe instance of multierror
 func NewMultiError() *MultiError {
-	return &MultiError{
-		mutex: &sync.Mutex{},
-	}
+	return new(MultiError)
 }
 
 // Push adds an error to MultiError.
@@ -29,6 +27,8 @@ func (m *MultiError) Push(errString string) {
 
 // HasError checks if MultiError has any error.
 func (m *MultiError) HasError() error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	if len(m.errs) == 0 {
 		return nil
 	}
@@ -39,6 +39,8 @@ func (m *MultiError) HasError() error {
 // Error implements error interface.
 func (m *MultiError) Error() string {
 	formattedError := make([]string, len(m.errs))
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	for i, e := range m.errs {
 		formattedError[i] = e.Error()
 	}

--- a/multierror_test.go
+++ b/multierror_test.go
@@ -1,7 +1,6 @@
 package valkyrie
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +8,7 @@ import (
 )
 
 func TestMultiErrorValidation(t *testing.T) {
-	me := &MultiError{mutex: new(sync.Mutex)}
+	me := &MultiError{}
 	me.Push("one")
 	me.Push("two")
 
@@ -19,7 +18,7 @@ func TestMultiErrorValidation(t *testing.T) {
 }
 
 func TestMultiErrorRespresentation(t *testing.T) {
-	me := &MultiError{mutex: new(sync.Mutex)}
+	me := &MultiError{}
 	me.Push("one")
 	me.Push("two")
 
@@ -31,7 +30,7 @@ func TestMultiErrorRespresentation(t *testing.T) {
 }
 
 func TestMultiErrorWithoutErrorsValidationIsNil(t *testing.T) {
-	me := &MultiError{mutex: new(sync.Mutex)}
+	me := &MultiError{}
 
 	err := me.HasError()
 
@@ -39,7 +38,7 @@ func TestMultiErrorWithoutErrorsValidationIsNil(t *testing.T) {
 }
 
 func TestMultiErrorRespresentationIsEmpty(t *testing.T) {
-	me := &MultiError{mutex: new(sync.Mutex)}
+	me := &MultiError{}
 
 	res := me.Error()
 


### PR DESCRIPTION
- Redefine MultiError.mutex to be a value, not a pointer. The zero value
of MultiError is now usable without resorting to a constructor.
- Fix missing locking in HasError and Error. Any time m.errs is
consulted m.mutex must be held.